### PR TITLE
Add metrics provider for flexvolume plugin

### DIFF
--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -32,7 +32,6 @@ type flexVolumeMounter struct {
 	// the considered volume spec
 	spec     *volume.Spec
 	readOnly bool
-	volume.MetricsNil
 }
 
 var _ volume.Mounter = &flexVolumeMounter{}

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -186,6 +186,7 @@ func (plugin *flexVolumePlugin) newMounterInternal(spec *volume.Spec, pod *api.P
 			podNamespace:          pod.Namespace,
 			podServiceAccountName: pod.Spec.ServiceAccountName,
 			volName:               spec.Name(),
+                        MetricsProvider: volume.NewMetricsStatFS(plugin.host.GetPodVolumeDir(pod.UID, utilstrings.EscapeQualifiedNameForDisk(sourceDriver), spec.Name())),
 		},
 		runner:   runner,
 		spec:     spec,
@@ -208,6 +209,7 @@ func (plugin *flexVolumePlugin) newUnmounterInternal(volName string, podUID type
 			plugin:     plugin,
 			podUID:     podUID,
 			volName:    volName,
+                        MetricsProvider: volume.NewMetricsStatFS(plugin.host.GetPodVolumeDir(podUID, utilstrings.EscapeQualifiedNameForDisk(plugin.driverName), volName)),
 		},
 		runner: runner,
 	}, nil

--- a/pkg/volume/flexvolume/unmounter.go
+++ b/pkg/volume/flexvolume/unmounter.go
@@ -31,7 +31,6 @@ type flexVolumeUnmounter struct {
 	*flexVolume
 	// Runner used to teardown the volume.
 	runner exec.Interface
-	volume.MetricsNil
 }
 
 var _ volume.Unmounter = &flexVolumeUnmounter{}

--- a/pkg/volume/flexvolume/volume.go
+++ b/pkg/volume/flexvolume/volume.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
+        "k8s.io/kubernetes/pkg/volume"
 )
 
 type flexVolume struct {
@@ -42,6 +43,7 @@ type flexVolume struct {
 	volName string
 	// the underlying plugin
 	plugin *flexVolumePlugin
+        volume.MetricsProvider
 }
 
 // volume.Volume interface


### PR DESCRIPTION

**=======Tests (results highlighted)=======**
**$kubectl proxy
$curl 127.0.0.1:8001/api/v1/nodes/10.187.14.110/proxy/stats/summary**

..
..
   {
    "podRef": {
     **"name": "pod1-claim51",**
     "namespace": "default",
     "uid": "7b1dc7a4-9a42-11e8-9364-9e42d474fa74"
    },
    "startTime": "2018-08-07T13:45:30Z",
    "containers": [
     {
      "name": "container-name",
      "startTime": "2018-08-07T13:45:34Z",
      "cpu": {
       "time": "2018-08-08T22:48:06Z",
       "usageNanoCores": 37426354,
       "usageCoreNanoSeconds": 1481673588111
      },
      "memory": {
       "time": "2018-08-08T22:48:06Z",
       "usageBytes": 90435584,
       "workingSetBytes": 88260608,
       "rssBytes": 76914688,
       "pageFaults": 23190791,
       "majorPageFaults": 83
      },
      "rootfs": {
       "time": "2018-08-08T22:48:06Z",
       "availableBytes": 92791775232,
       "capacityBytes": 105553100800,
       "usedBytes": 53248,
       "inodesFree": 6299058,
       "inodes": 6553600,
       "inodesUsed": 14
      },
      "logs": {
       "time": "2018-08-08T22:48:06Z",
       "availableBytes": 92791775232,
       "capacityBytes": 105553100800,
       "usedBytes": 36864,
       "inodesFree": 6299058,
       "inodes": 6553600,
       "inodesUsed": 254542
      },
      "userDefinedMetrics": null
     }
    ],
    "cpu": {
     "time": "2018-08-08T22:48:13Z",
     "usageNanoCores": 35612891,
     "usageCoreNanoSeconds": 1481693053139
    },
    "memory": {
     "time": "2018-08-08T22:48:13Z",
     "usageBytes": 90722304,
     "workingSetBytes": 88547328,
     "rssBytes": 76922880,
     "pageFaults": 0,
     "majorPageFaults": 0
    },
    "network": {
     "time": "2018-08-08T22:48:12Z",
     "name": "eth0",
     "rxBytes": 648,
     "rxErrors": 0,
     "txBytes": 0,
     "txErrors": 0,
     "interfaces": [
      {
       "name": "tunl0",
       "rxBytes": 0,
       "rxErrors": 0,
       "txBytes": 0,
       "txErrors": 0
      },
      {
       "name": "eth0",
       "rxBytes": 648,
       "rxErrors": 0,
       "txBytes": 0,
       "txErrors": 0
      }
     ]
    },
    "volume": [
     {
      "time": "2018-08-08T22:47:41Z",
      "availableBytes": 2071076864,
      "capacityBytes": 2071089152,
      "usedBytes": 12288,
      "inodesFree": 505628,
      "inodes": 505637,
      "inodesUsed": 9,
      "name": "default-token-n9255"
     },
     **{
      "time": "2018-08-08T22:47:41Z",
      "availableBytes": 19867033600,
      "capacityBytes": 21003628544,
      "usedBytes": 46075904,
      "inodesFree": 1310708,
      "inodes": 1310720,
      "inodesUsed": 12,
      "name": "pvc-name",
      "pvcRef": {
       "name": "claim5-block-bronze",
       "namespace": "default"
      }**
     }
    ],
    "ephemeral-storage": {
     "time": "2018-08-08T22:48:14Z",
     "availableBytes": 92791775232,
     "capacityBytes": 105553100800,
     "usedBytes": 90112,
     "inodesFree": 6299058,
     "inodes": 6553600,
     "inodesUsed": 14
    }
   }
  ]
 }




<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
